### PR TITLE
Extended available options for selecting data; instr method not case-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ print (mb.field_labels.keys()) # See which fields are available
 mb.show() # List the selected bursts
 
 time = mb['time'] # Get a field as a numpy array (automatically time-ordered)
+mb[time > 54000.].show() # show all the bursts after the specified time
 flux = mb['bpflux'] # Flux in 1e-9 erg/s/cm2
+sub = mb[['time','bpflux']] # extract a subset of the columns, for the given selection
 mb.create_distance_correction() # Include distance information from Sources()
 luminosity = (flux*mb['distcor']).to('erg s-1') # Isotropic peak luminosity in erg/s
 pca = mb.instr_like('pca') # Get index array for bursts observed with PCA


### PR DESCRIPTION
…sensitive

See __getitem__; can now pass an array of IDs, fields, or booleans.
Giving a single ID or list will return the astropy Table including just those events.
Giving an array of fields will return a table including only those fields for the current selection.
Providing a Boolean (of the same length as the selection) will return a Table including only the events for which the array is True