### PR TITLE
Load sources as pandas table, optionally from db

### DIFF
--- a/minbar/build.py
+++ b/minbar/build.py
@@ -169,7 +169,7 @@ def write_wiki_csv(outfile='minbar_sources_new.csv', con=None):
     """
 
     new_connection = False
-    if con is None
+    if con is None:
         con = connect_db()
         new_connection = True
 


### PR DESCRIPTION
Cleaned up the definition of the Sources table, and implemented it instead as a Pandas table. Made sure to close the FITS file after reading. Some simple checking of the integrity of the table and the associated information.

Also now can read in the (extended, post-DR2) source table from the database, which otherwise should operate as for the FITS table